### PR TITLE
Don't directly access ::Rails::Application in VersionStrategy#registered_engines

### DIFF
--- a/lib/cell/rails3_0_strategy.rb
+++ b/lib/cell/rails3_0_strategy.rb
@@ -67,8 +67,8 @@ end
 
 module Cells::Engines
   module VersionStrategy
-    def registered_engines
-      ::Rails::Application.railties.engines
+    def registered_engines(app)
+      app.railties.engines
     end
     
     def existent_directories_for(path)

--- a/lib/cell/rails3_1_strategy.rb
+++ b/lib/cell/rails3_1_strategy.rb
@@ -25,7 +25,7 @@ end
 
 module Cells::Engines
   module VersionStrategy
-    def registered_engines
+    def registered_engines(app)
       ::Rails::Application::Railties.engines
     end
     

--- a/lib/cells/engines.rb
+++ b/lib/cells/engines.rb
@@ -39,10 +39,10 @@ module Cells
     #  
     # Defaults <tt>config.view_path_engines</tt> to all loaded <tt>Rails::Engine</tt>s.
     #
-    def self.append_engines_view_paths_for(config, app)
-      return if config.view_path_engines == false
+    def self.append_engines_view_paths_for(app)
+      return if Cell::Base.config.view_path_engines == false
 
-      engines = config.view_path_engines || registered_engines(app)  #::Rails::Application::Railties.engines
+      engines = Cell::Base.config.view_path_engines || registered_engines(app)  #::Rails::Application::Railties.engines
       engines.each {|engine| append_engine_view_path!(engine) }
     end
 

--- a/lib/cells/engines.rb
+++ b/lib/cells/engines.rb
@@ -39,10 +39,10 @@ module Cells
     #  
     # Defaults <tt>config.view_path_engines</tt> to all loaded <tt>Rails::Engine</tt>s.
     #
-    def self.append_engines_view_paths_for(config)
+    def self.append_engines_view_paths_for(config, app)
       return if config.view_path_engines == false
 
-      engines = config.view_path_engines || registered_engines  #::Rails::Application::Railties.engines
+      engines = config.view_path_engines || registered_engines(app)  #::Rails::Application::Railties.engines
       engines.each {|engine| append_engine_view_path!(engine) }
     end
 

--- a/lib/cells/railtie.rb
+++ b/lib/cells/railtie.rb
@@ -13,7 +13,7 @@ module Cells
     end
     
     initializer "cells.setup_engines_view_paths" do |app|
-      Cells::Engines.append_engines_view_paths_for(app.config.action_controller, app)
+      Cells::Engines.append_engines_view_paths_for(app)
     end
     
     rake_tasks do

--- a/lib/cells/railtie.rb
+++ b/lib/cells/railtie.rb
@@ -13,7 +13,7 @@ module Cells
     end
     
     initializer "cells.setup_engines_view_paths" do |app|
-      Cells::Engines.append_engines_view_paths_for(app.config.action_controller)
+      Cells::Engines.append_engines_view_paths_for(app.config.action_controller, app)
     end
     
     rake_tasks do


### PR DESCRIPTION
Hi,

On updating to Cells 3.8.3, our Rails 3.0 app started spitting out the following deprecation message:

    DEPRECATION WARNING: Calling a method in Rails::Application is deprecated, please call it directly in your application constant WhateverApp::Application

I traced this down to the Rail 3.0 [lookup for registered engines](https://github.com/apotonick/cells/blob/master/lib/cell/rails3_0_strategy.rb#L76), which talks to `Rails::Application` directly. The attached commit modifies the calls so that the app instance is passed through, and the old engines lookup can be used.

It's not ready to merge, however, because I've hit a possible bug in this area. The documentation says that adding the following to an initializer will disable the view_path_engines additions:

    Cell::Base.config.view_path_engines = false

However the `append_engines_view_paths_for` method doesn't actually look at this config setting, as far as I can see - instead, it's talking to the application's `action_controller` config hash:

    # lib/cells/railtie.rb
    require "rails/railtie"
    
    module Cells
      class Railtie < ::Rails::Railtie
        #...
        initializer "cells.setup_engines_view_paths" do |app|
          Cell::Engines.append_engines_view_paths_for(app.config.action_controller)
        end
      end
    end

    # lib/cells/engines.rb
    #...
    module Engines
      extend VersionStrategy
    
      def self.append_engines_view_paths_for(config)
        return if config.view_path_engines == false

        engines = config.view_path_engines || registered_engines(app)  #::Rails::Application::Railties.engines
        engines.each {|engine| append_engine_view_path!(engine) }
      end
    end

There's no such setting in the `action_controller` config hash, so it seems that all registered Engines are always appended to the view path.

Should this check be talking to `Cell::Base.config` as per the documentation, or should it be looking elsewhere, and the documentation needs updating? If you let me know what the intention is, I'll update this pull request as necessary.

Cheers,
Simon