### PR TITLE
Making flash and cookies available in cells views and controllers

### DIFF
--- a/lib/cell/rails.rb
+++ b/lib/cell/rails.rb
@@ -4,10 +4,10 @@ module Cell
   class Rails < Rack
     # When this file is included we can savely assume that a rails environment with caching, etc. is available.
     include ActionController::RequestForgeryProtection
-    
+
     abstract!
-    delegate :session, :params, :request, :config, :env, :url_options, :to => :parent_controller
-    
+    delegate :flash, :cookies, :session, :params, :request, :config, :env, :url_options, :to => :parent_controller
+
     class << self
       def cache_store
         # FIXME: i'd love to have an initializer in the cells gem that _sets_ the cache_store attr instead of overriding here.
@@ -15,30 +15,30 @@ module Cell
         # DISCUSS: should this be in Cell::Rails::Caching ?
         ActionController::Base.cache_store
       end
-      
+
       def expire_cache_key(key, *args)  # FIXME: move to Rails.
         expire_cache_key_for(key, cache_store ,*args)
       end
-      
+
     private
       # Run builder block in controller instance context.
       def run_builder_block(block, controller, *args)
         controller.instance_exec(*args, &block)
       end
     end
-    
-    
+
+
     attr_reader :parent_controller
-    
+
     def initialize(parent_controller)
       super
       @parent_controller = parent_controller
     end
-    
+
     def cache_configured?
       ActionController::Base.send(:cache_configured?) # DISCUSS: why is it private?
     end
-    
+
     def cache_store
       self.class.cache_store  # in Rails, we have a global cache store.
     end


### PR DESCRIPTION
Hello. Thank you for your gem. It is very usefull and I think that in future it will be used in every rails app. And I want to try helping you to make it better.

I believe that having flash and cookies available in cell have more pros than cons. I know that you can use it like 
`` parent_controller.cookies `` 
or
`` parent_controller.flash``
But sometimes it's not the way to solve this problem.
For example, you can have a helper method that uses cookies, and you need to rewrite helper's method to use it in cell because you have to use ``parent_controller`` for using cookies.