### PR TITLE
Set the value of lookup_context.formats to the parent controller's formats if the format option not exists

### DIFF
--- a/lib/cell/rails3_0_strategy.rb
+++ b/lib/cell/rails3_0_strategy.rb
@@ -57,7 +57,7 @@ module Cell
     end
     
     def process_opts_for(opts, state)
-      lookup_context.formats = opts.delete(:format) if opts[:format]
+      lookup_context.formats = opts[:format] ? [opts.delete(:format)] : parent_controller.formats
       
       opts[:template] = find_family_view_for_state(opts.delete(:view) || state)
     end

--- a/lib/cell/rails3_1_strategy.rb
+++ b/lib/cell/rails3_1_strategy.rb
@@ -17,7 +17,7 @@ module Cell
     def process_opts_for(opts, state)
       opts[:action] = opts[:view] || state
       
-      lookup_context.formats = [opts.delete(:format)] if opts[:format]
+      lookup_context.formats = opts[:format] ? [opts.delete(:format)] : parent_controller.formats
     end
   end
 end

--- a/lib/cell/rails4_0_strategy.rb
+++ b/lib/cell/rails4_0_strategy.rb
@@ -17,7 +17,7 @@ module Cell
     def process_opts_for(opts, state)
       opts[:action] = opts[:view] || state
       
-      lookup_context.formats = [opts.delete(:format)] if opts[:format]
+      lookup_context.formats = opts[:format] ? [opts.delete(:format)] : parent_controller.formats
     end
   end
 end


### PR DESCRIPTION
In ```#process_opts_for```, the value of ```lookup_context.formats``` is default if we don't give the ```opts[:format]```, but i think the value should be its **parent controller's** ```lookup_context.formats``` only if we give the ```opts[:format]```.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/apotonick/cells/161)
<!-- Reviewable:end -->
