### PR TITLE
lib/cell/haml_support_that_SUCKS, should make sure user's project defined?(is_haml?)

### DIFF
--- a/lib/cell/haml_support_that_SUCKS.rb
+++ b/lib/cell/haml_support_that_SUCKS.rb
@@ -2,12 +2,12 @@
 
 module WhyDoWeHaveToOverrideRailsHelpersToMakeHamlWork
   def output_buffer_with_haml
-    return haml_buffer.buffer if is_haml?
+    return haml_buffer.buffer if defined?(is_haml?) && is_haml?
     output_buffer_without_haml
   end
 
   def set_output_buffer_with_haml(new_buffer)
-    if is_haml?
+    if defined?(is_haml?) && is_haml?
       if Haml::Util.rails_xss_safe? && new_buffer.is_a?(ActiveSupport::SafeBuffer)
         new_buffer = String.new(new_buffer)
       end


### PR DESCRIPTION
Cells 4.0 can't work when user's project don't use haml, and it will shows no method error `is_haml?`.
I added a check to make sure they have `is_haml?` method in `#output_buffer_with_haml` and `#set_output_buffer_with_haml`.

It's about Gemfile list, and I have no idea about how to write test… sorry for this.