### PR TITLE
Search all view paths for requested template

### DIFF
--- a/lib/cell/templates.rb
+++ b/lib/cell/templates.rb
@@ -3,9 +3,12 @@ module Cell
   class Templates
     # prefixes could be instance variable as they will never change.
     def [](bases, prefixes, view, engine, formats=nil)
-      base = bases.first # FIXME.
+      bases.each do |base|
+        template = find_template(base, prefixes, view, engine)
+        return template if template
+      end
 
-      find_template(base, prefixes, view, engine)
+      nil
     end
 
   private

--- a/lib/cell/templates.rb
+++ b/lib/cell/templates.rb
@@ -3,12 +3,12 @@ module Cell
   class Templates
     # prefixes could be instance variable as they will never change.
     def [](bases, prefixes, view, engine, formats=nil)
-      bases.each do |base|
-        template = find_template(base, prefixes, view, engine)
-        return template if template
-      end
+      view = "#{view}.#{engine}"
 
-      nil
+      cache.fetch(prefixes, view) do |prefix|
+        # this block is run once per cell class per process, for each prefix/view tuple.
+        find_template(bases, prefix, view)
+      end
     end
 
   private
@@ -17,13 +17,12 @@ module Cell
       @cache ||= Cache.new
     end
 
-    def find_template(base, prefixes, view, engine)
-      view = "#{view}.#{engine}"
-
-      cache.fetch(prefixes, view) do |prefix|
-        # this block is run once per cell class per process, for each prefix/view tuple.
-        create(base, prefix, view)
+    def find_template(bases, prefix, view)
+      bases.each do |base|
+        template = create(base, prefix, view) and return template
       end
+
+      nil
     end
 
     def create(base, prefix, view)

--- a/test/templates_test.rb
+++ b/test/templates_test.rb
@@ -5,6 +5,7 @@ class TemplatesTest < MiniTest::Spec
   Templates = Cell::Templates
 
   let (:base) { ['test/fixtures'] }
+  let (:bases) { ['bogus/path', 'test/fixtures'] }
 
   # existing.
   it { Templates.new[base, ['bassist'], 'play', 'erb'].file.must_equal 'test/fixtures/bassist/play.erb' }
@@ -12,6 +13,8 @@ class TemplatesTest < MiniTest::Spec
   # not existing.
   it { Templates.new[base, ['bassist'], 'not-here', 'erb'].must_equal nil }
 
+  # search all bases
+  it { Templates.new[bases, ['bassist'], 'play', 'erb'].file.must_equal 'test/fixtures/bassist/play.erb' }
 
   # different caches for different classes
 


### PR DESCRIPTION
This is a simple patch, iterating over all supplied bases until a requested template is found. It allows Cell::ViewModel.view_paths to be appended to, so that (for instance) engines can bundle cells.

(Related: the docs seem to suggest that cells can be bundled in engines, but maybe that was pre-4.0? At any rate, I couldn't get it to work in 4.0 without the changes in this patch.)

I'm embarrassed that there is no test to accompany this patch, but I'll be honest---I spent a good hour trying to get the tests to run, and failed miserably. If you can point me at instructions for getting the dev environment configured, I'd be happy to work some tests into this patch, but as it is...a guy's gotta get work done to pay the bills, you know? :)