### PR TITLE
Use proper lookup when including template modules

### DIFF
--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -50,9 +50,9 @@ module Cell
     # TODO: allow to turn off this.
     initializer "cells.include_template_module", after: "cells.include_default_helpers" do
       # yepp, this is happening. saves me a lot of coding in each extension.
-      ViewModel.send(:include, Cell::Erb) if Cell.const_defined?(:Erb)
-      ViewModel.send(:include, Cell::Haml) if Cell.const_defined?(:Haml)
-      ViewModel.send(:include, Cell::Slim) if Cell.const_defined?(:Slim)
+      ViewModel.send(:include, Cell::Erb) if Cell.const_defined?(:Erb, false)
+      ViewModel.send(:include, Cell::Haml) if Cell.const_defined?(:Haml, false)
+      ViewModel.send(:include, Cell::Slim) if Cell.const_defined?(:Slim, false)
     end
     #   ViewModel.template_engine = app.config.app_generators.rails.fetch(:template_engine, 'erb').to_s
 


### PR DESCRIPTION
Using "const_defined?" without false as the second parameter also looks
for the constant in all ancestor classes. So when my app includes
the "haml" gem but not "cells-haml", it would still return true and
raise an exception because it cannot find the Cells module.