### PR TITLE
undefined method `env' for Cell::Rails:Class (NoMethodError)

### DIFF
--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -57,7 +57,7 @@ module Cell
     #   ViewModel.template_engine = app.config.app_generators.rails.fetch(:template_engine, 'erb').to_s
 
     initializer('cells.development') do |app|
-      if Rails.env == "development"
+      if ::Rails.env == "development"
         require "cell/development"
         ViewModel.send(:include, Development)
       end


### PR DESCRIPTION
I was hitting this issue running an upgrade from rails 3.2 to rails 4.2.1 and cells 3.9.1 to cells 4.0.0.