### PR TITLE
Include ActionView::Helpers::FormHelper by default

### DIFF
--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -36,11 +36,15 @@ module Cell
     initializer "cells.include_default_helpers" do
       # include asset helpers (image_path, font_path, ect)
       ViewModel.class_eval do
-        include ActionView::Helpers::UrlHelper
+        # The following two included by ActionView::Helpers::FormHelper:
+        #
+        #   ActionView::Helpers::UrlHelper
+        #   ActionView::Helpers::FormTagHelper
+        #
+        include ActionView::Helpers::FormHelper
         include ::Cell::RailsExtensions::HelpersAreShit
 
         include ActionView::Helpers::AssetTagHelper
-        include ActionView::Helpers::FormTagHelper
       end
 
       # set VM#cache_store, etc.

--- a/test/rails4.2/app/cells/form_for_cell.rb
+++ b/test/rails4.2/app/cells/form_for_cell.rb
@@ -1,6 +1,5 @@
 class FormForCell < Cell::ViewModel
   include ActionView::RecordIdentifier
-  include ActionView::Helpers::FormHelper
 
   def show
     render

--- a/test/rails4.2/app/cells/form_tag/show.erb
+++ b/test/rails4.2/app/cells/form_tag/show.erb
@@ -1,0 +1,5 @@
+<%= form_tag songs_path do %>
+  Second
+  <%= text_field_tag :id %>
+  <%= submit_tag "Save" %>
+<% end %>

--- a/test/rails4.2/app/cells/form_tag_cell.rb
+++ b/test/rails4.2/app/cells/form_tag_cell.rb
@@ -1,0 +1,5 @@
+class FormTagCell < Cell::ViewModel
+  def show
+    render
+  end
+end

--- a/test/rails4.2/app/cells/formtastic_cell.rb
+++ b/test/rails4.2/app/cells/formtastic_cell.rb
@@ -1,6 +1,5 @@
 class FormtasticCell < Cell::ViewModel
   include ActionView::RecordIdentifier
-  include ActionView::Helpers::FormHelper
   include Formtastic::Helpers::FormHelper
 
   def show

--- a/test/rails4.2/app/cells/simple_form_cell.rb
+++ b/test/rails4.2/app/cells/simple_form_cell.rb
@@ -1,6 +1,5 @@
 class SimpleFormCell < Cell::ViewModel
   include ActionView::RecordIdentifier
-  include ActionView::Helpers::FormHelper
   include SimpleForm::ActionViewExtensions::FormHelper
 
   # include ActiveSupport::Configurable

--- a/test/rails4.2/config/initializers/formtastic.rb
+++ b/test/rails4.2/config/initializers/formtastic.rb
@@ -1,0 +1,2 @@
+Formtastic::FormBuilder.action_class_finder = Formtastic::ActionClassFinder
+Formtastic::FormBuilder.input_class_finder = Formtastic::InputClassFinder

--- a/test/rails4.2/engines/my_engine/my_engine.gemspec
+++ b/test/rails4.2/engines/my_engine/my_engine.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |s|
   s.version     = MyEngine::VERSION
   s.authors     = ["Alexander Huber"]
   s.email       = ["alih83@gmx.de"]
-  s.homepage    = "TODO"
-  s.summary     = "TODO: Summary of MyEngine."
-  s.description = "TODO: Description of MyEngine."
+  s.homepage    = "https://github.com/apotonick/cells"
+  s.summary     = "Summary of MyEngine."
+  s.description = "Description of MyEngine."
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]

--- a/test/rails4.2/test/integration/form_tag_test.rb
+++ b/test/rails4.2/test/integration/form_tag_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class FormTagTestTest < MiniTest::Spec
+  include Cell::Testing
+  controller SongsController
+
+  it do
+    cell("form_tag").().gsub(/\s\s/, "").must_equal %{<form action=\"/songs\" accept-charset=\"UTF-8\" method=\"post\"><input name=\"utf8\" type=\"hidden\" value=\"&#x2713;\" /> Second <input type=\"text\" name=\"id\" id=\"id\" /> <input type=\"submit\" name=\"commit\" value=\"Save\" />
+</form>}
+  end
+end


### PR DESCRIPTION
```ruby
<%= "With all the love to rails helpers" do -%>
```
This adds `ActionView::Helpers::FormHelper` into the included by default rails helpers.
It allows to avoid overriding `Cell::Erb`'s `capture` re-implementation.

Also, as soon as `ActionView::Helpers::FormHelper` includes `UrlHelper` and `FormTagHelper` it's no need to include them once again.

It also fixes warnings in `test/rails4.2` test suite.
```ruby
<% end %>
```