### PR TITLE
Make Partial work with multiple view paths

### DIFF
--- a/lib/cell/partial.rb
+++ b/lib/cell/partial.rb
@@ -10,7 +10,7 @@ module Cell::ViewModel::Partial
     view      = parts.pop
     view      = "_#{view}"
     view     += ".#{options[:formats].first}" if options[:formats]
-    prefixes  = self.class.view_paths.collect { |path| parts.unshift(path).join("/") }
+    prefixes  = self.class.view_paths.collect { |path| ([path] + parts).join("/") }
 
     options.merge!(view: view, prefixes: prefixes)
   end

--- a/test/partial_test.rb
+++ b/test/partial_test.rb
@@ -21,7 +21,15 @@ class PartialTest < MiniTest::Spec
     end
   end
 
+  class WithPartialAndManyViewPaths < WithPartial
+    self.view_paths << ['app/views']
+  end
+
   it { WithPartial.new(nil).show.must_equal "I Am Wrong And I Am Right" }
   it { WithPartial.new(nil).show_with_format.must_equal "<xml>I Am Wrong And I Am Right</xml>" }
   it { WithPartial.new(nil).show_without_partial.must_equal "Adenosine Breakdown" }
+
+  it { WithPartialAndManyViewPaths.new(nil).show.must_equal "I Am Wrong And I Am Right" }
+  it { WithPartialAndManyViewPaths.new(nil).show_with_format.must_equal "<xml>I Am Wrong And I Am Right</xml>" }
+  it { WithPartialAndManyViewPaths.new(nil).show_without_partial.must_equal "Adenosine Breakdown" }
 end


### PR DESCRIPTION
My use case is that I need to have more that one view path and render a global partial within a cell. This is probably totally wrong but I'm upgrading an app with cells 3 to 4 and this was allowed before ;)

The thing is, when there is a in-place mangling with `view_paths` in `Partial` module (with `unshift`) it yields really ugly and unexpected results. And does not allow me to do what I want. I think it is a better idea to create a new array instead of `unshift`. Test case added.