### PR TITLE
I18N tests for translations with absolute and relative paths

### DIFF
--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class I18nTest < MiniTest::Spec
+  class I18nCell < Cell::ViewModel
+    include ActionView::Helpers::TranslationHelper
+
+    def translate_relative(path=nil)
+      @virtual_path = path if path
+      t('.text')
+    end
+
+    def translate_absolute
+      t('test.text')
+    end
+  end
+
+  I18n.backend = I18n::Backend::KeyValue.new({})
+  I18n.backend.store_translations(:en,
+                                  { 'test.text' => 'test text' },
+                                  escape: false)
+
+  # Translate text specified by an absolute path
+  it { I18nCell.new.translate_absolute.must_equal 'test text' }
+
+  # Translate text specified by an relative path
+  it { I18nCell.new.translate_relative.must_equal 'test text' }
+
+  # Translate text specified by an relative path, explicitly set
+  it { I18nCell.new.translate_relative('test').must_equal 'test text' }
+
+end


### PR DESCRIPTION
The relative-path test that expects Cells to set the path
currently generates an error but the others pass if that one
is commented out.

All tests should pass if Cells sets @virtual_path appropriately.