### PR TITLE
WIP: support for ActiveSupport::Notifications

### DIFF
--- a/lib/cell/logging.rb
+++ b/lib/cell/logging.rb
@@ -26,7 +26,7 @@ module Cell
 
       def log(message, event)
         self.class.runtime += event.duration
-        ::Rails.logger.info color("  #{message} (#{"%.1f" % event.duration}ms)", BLUE)
+        ::Rails.logger.info color("  #{message} (#{"%.2f" % event.duration}ms)", BLUE)
       end
       LogSubscriber.attach_to :cell
     end
@@ -54,7 +54,7 @@ module Cell
       module ClassMethods
         def log_process_action(payload)
           messages, cell_runtime = super, payload[:cell_runtime]
-          messages << ("Cells: %.1fms" % cell_runtime.to_f) if cell_runtime
+          messages << ("Cells: %.2fms" % cell_runtime.to_f) if cell_runtime
           messages
         end
       end

--- a/lib/cell/logging.rb
+++ b/lib/cell/logging.rb
@@ -1,0 +1,87 @@
+module Cell
+  module Logging
+    class LogSubscriber < ActiveSupport::LogSubscriber
+      def self.runtime=(value)
+        Thread.current[:cell_log_runtime] = value
+      end
+
+      def self.runtime
+        Thread.current[:cell_log_runtime] ||= 0
+      end
+
+      def self.reset_runtime
+        rt, self.runtime = runtime, 0
+        rt
+      end
+
+      def render(event)
+        log "Rendered #{event.payload[:template]} by #{event.payload[:cell].class.name}", event
+      end
+
+      def call(event)
+        log "Rendered #{event.payload[:cell].class.name}##{event.payload[:state]}", event
+      end
+
+      private
+
+      def log(message, event)
+        self.class.runtime += event.duration
+        ::Rails.logger.info color("  #{message} (#{"%.1f" % event.duration}ms)", BLUE)
+      end
+      LogSubscriber.attach_to :cell
+    end
+
+    module ControllerRuntime
+      extend ActiveSupport::Concern
+
+      protected
+
+      attr_internal :cell_runtime
+
+      def cleanup_view_runtime
+        before_render = Cell::Logging::LogSubscriber.reset_runtime
+        runtime = super
+        after_render = Cell::Logging::LogSubscriber.reset_runtime
+        self.cell_runtime = before_render + after_render
+        runtime - after_render
+      end
+
+      def append_info_to_payload(payload)
+        super
+        payload[:cell_runtime] = (cell_runtime || 0) + Cell::Logging::LogSubscriber.runtime
+      end
+
+      module ClassMethods
+        def log_process_action(payload)
+          messages, cell_runtime = super, payload[:cell_runtime]
+          messages << ("Cells: %.1fms" % cell_runtime.to_f) if cell_runtime
+          messages
+        end
+      end
+    end
+
+    ActiveSupport.on_load(:action_controller) do
+      include Cell::Logging::ControllerRuntime
+    end
+
+    module Instrumentation
+      def render(options = {})
+        _options = normalize_options(options)
+        template_file = find_template(_options).file.gsub(/^app\/\w*\//, "")
+        ActiveSupport::Notifications.instrument "render.cell", cell: self, options: _options, template: template_file do
+          super(_options)
+        end
+      end
+
+      def call(state = :show, *args, &block)
+        ActiveSupport::Notifications.instrument "call.cell", cell: self, state: state, args: args do
+          super
+        end
+      end
+    end
+
+    ViewModel.class_eval do
+      include Cell::Logging::Instrumentation
+    end
+  end
+end

--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -62,6 +62,10 @@ module Cell
       end
     end
 
+    initializer('cells.logging') do |app|
+      require "cell/logging"
+    end
+
     rake_tasks do
       load 'tasks/cells.rake'
     end


### PR DESCRIPTION
This PR is still work in progress, feedback and feature requests are welcome!

This PR adds some use full informations to the rails log:
![](https://cloud.githubusercontent.com/assets/165599/10191732/09292c68-6777-11e5-98c5-6afdd266ce52.jpg)

TODOs:
- [ ] Rails 3.2 has a different Notification API
- [ ] Based on the screeshot, the sum of all cells time in the last row is wrong, because of `Rendered Post::Cell::Show#show (172.9ms)` includes the time from `Rendered post/views/show.haml by Post::Cell::Show (46.8ms)`
- [ ] `Instrumentation#render` need't be changed to reflect changes of `normalize_options` during #331 