### PR TITLE
discussion don't double cache

### DIFF
--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -114,7 +114,7 @@ module Cell
 
     private
       def render_to_string(options)
-        template = find_template(options) # TODO: cache template with path/lookup keys.
+        template = find_template(options)
 
         content  = render_template(template, options)
 


### PR DESCRIPTION
`# TODO: cache template with path/lookup keys.` [source](https://github.com/apotonick/cells/blob/bee267927a607d1f847ebb1d3c8be597e5d99e4a/lib/cell/view_model.rb#L117)

Should here really a caching?
`find_template` calls `template_for` which calls `Templates#[]` which already caches.