### PR TITLE
Optimize render

### DIFF
--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -108,7 +108,7 @@ module Cell
 
       # render :show
       def render(options={})
-        options = normalize_options(options, caller)
+        options = normalize_options(options)
         render_to_string(options)
       end
 
@@ -196,8 +196,7 @@ module Cell
     end
     include TemplateFor
 
-
-    def normalize_options(options, caller) # TODO: rename to #setup_options! to be inline with Trb.
+    def normalize_options(options) # TODO: rename to #setup_options! to be inline with Trb.
       options = if options.is_a?(Hash)
         # TODO: speedup by not doing state_for_implicit_render.
         {view: state_for_implicit_render(caller)}.merge(options)
@@ -220,7 +219,7 @@ module Cell
 
 
     def state_for_implicit_render(caller)
-      caller[0].match(/`(\w+)/)[1]
+      caller[1].match(/`(\w+)/)[1]
     end
 
     include Layout

--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -198,7 +198,6 @@ module Cell
 
     def normalize_options(options) # TODO: rename to #setup_options! to be inline with Trb.
       options = if options.is_a?(Hash)
-        # TODO: speedup by not doing state_for_implicit_render.
         {view: state_for_implicit_render(caller(2, 1))}.merge(options)
       else
         {view: options.to_s}

--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -198,7 +198,8 @@ module Cell
 
     def normalize_options(options) # TODO: rename to #setup_options! to be inline with Trb.
       options = if options.is_a?(Hash)
-        {view: state_for_implicit_render(caller(2, 1))}.merge(options)
+        _caller = RUBY_VERSION < "2.0" ? caller(2) : caller(2, 1)
+        {view: state_for_implicit_render(_caller)}.merge(options)
       else
         {view: options.to_s}
       end

--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -199,7 +199,7 @@ module Cell
     def normalize_options(options) # TODO: rename to #setup_options! to be inline with Trb.
       options = if options.is_a?(Hash)
         # TODO: speedup by not doing state_for_implicit_render.
-        {view: state_for_implicit_render(caller)}.merge(options)
+        {view: state_for_implicit_render(caller(2, 1))}.merge(options)
       else
         {view: options.to_s}
       end
@@ -219,7 +219,7 @@ module Cell
 
 
     def state_for_implicit_render(caller)
-      caller[1].match(/`(\w+)/)[1]
+      caller[0].match(/`(\w+)/)[1]
     end
 
     include Layout


### PR DESCRIPTION
### This PR optimizes `ViewModel#render` in two cases / ways.

**First case 'explizit render':**  Before this PR `#render` calls `caller` and give the result to `normalize_options`, which don't work with the `caller` when a explizit view name is used.
The PR makes this case ~25% faster

**Second case 'implizit render':** Before this PR the complete `caller` stack would be read, but we only need the last 2 segments. By only reading the 2 last segments, the `caller` call is faster and don't produce big arrays, which optimize the memory footprint.
The PR makes this case ~20% faster

Note: all test are based on this Cell, Model and View:
```ruby
model = "test"
class TestCell < Cell::ViewModel
  def index
    render
  end

  def index_explizit
    render "index"
  end
end
```
```erb
<%= model %>
```

I also remove the `TODO: speedup by not doing state_for_implicit_render.` comment. I think this code don't need to optimize anymore, this is now only ~5% slower as the explizit way.