### PR TITLE
Allow class in `concept` helper.

### DIFF
--- a/lib/cell/concept.rb
+++ b/lib/cell/concept.rb
@@ -5,20 +5,19 @@ module Cell
 
     # TODO: this should be in Helper or something. this should be the only entry point from controller/view.
     class << self
-      def class_from_cell_name(name)
-        name.camelize.constantize
-      end
-
       def controller_path
         @controller_path ||= util.underscore(name.sub(/(::Cell$|Cell::)/, ''))
       end
+
+    private
+      def full_cell_name(name) name end
     end
 
     alias_method :concept, :cell # Concept#concept does exactly what #cell does: delegate to class builder.
 
     # Get nested cell in instance.
-    def cell(name, model=nil, options={})
-      ViewModel.cell(name, model, options.merge(controller: parent_controller)) # #cell calls need to be delegated to ViewModel.
+    def cell(name_or_class, model=nil, options={})
+      ViewModel.cell(name_or_class, model, options.merge(controller: parent_controller)) # #cell calls need to be delegated to ViewModel.
     end
 
     self_contained!

--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -32,9 +32,9 @@ module Cell
     attr_reader :model
 
     module Helpers
-      # Constantizes name, call builders and returns instance.
-      def cell(name, *args, &block) # classic Rails fuzzy API.
-        class_from_cell_name(name).(*args, &block)
+      # Constantizes name if needed, call builders and returns instance.
+      def cell(name_or_class, *args, &block) # classic Rails fuzzy API.
+        cell_class(name_or_class).(*args, &block)
       end
 
     private
@@ -71,8 +71,12 @@ module Cell
       end
 
     private
-      def class_from_cell_name(name)
-        "#{name}_cell".camelize.constantize
+      def cell_class(arg)
+        arg.respond_to?(:camelize) ? full_cell_name(arg).camelize.constantize : arg
+      end
+
+      def full_cell_name(name)
+        "#{name}_cell"
       end
     end
 

--- a/test/public_test.rb
+++ b/test/public_test.rb
@@ -21,9 +21,12 @@ class PublicTest < MiniTest::Spec
 
   # ViewModel.cell returns the cell instance.
   it { Cell::ViewModel.cell("public_test/song").must_be_instance_of SongCell }
+  it { Cell::ViewModel.cell(PublicTest::SongCell).must_be_instance_of SongCell }
 
   # Concept.cell simply camelizes the string before constantizing.
   it { Cell::Concept.cell("public_test/songs").must_be_instance_of Songs }
+
+  it { Cell::Concept.cell(PublicTest::Songs).must_be_instance_of Songs }
 
   # ViewModel.cell passes options to cell.
   it { Cell::ViewModel.cell("public_test/song", Object, genre: "Metal").initialize_args.must_equal [Object, {genre:"Metal"}] }


### PR DESCRIPTION
`= concept "foo/bar"` can be: `= concept Foo::Bar` and also `= cell "foo/bar"` can be: `= cell Foo::BarCell`