### PR TITLE
Fixes occasional test failure.

### DIFF
--- a/test/rails_extensions_test.rb
+++ b/test/rails_extensions_test.rb
@@ -19,33 +19,33 @@ class ViewExtensionsTest < ActionController::TestCase
   # #concept is available in controller views.
   test "concept(..).show" do
     get :view_with_concept_with_show
-    @response.body.must_equal "&lt;b&gt;Up For Breakfast&lt;/b&gt;" # TODO: test options/with twin.
+    assert_equal "&lt;b&gt;Up For Breakfast&lt;/b&gt;", @response.body # TODO: test options/with twin.
   end
 
   test "concept(..).call" do
     get :view_with_concept_with_call
-    @response.body.must_equal "<b>A Tale That Wasn't Right</b>" # TODO: test options/with twin.
+    assert_equal "<b>A Tale That Wasn't Right</b>", @response.body # TODO: test options/with twin.
   end
 
   test "concept(..) without #call" do
     get :view_with_concept_without_call
-    @response.body.must_equal "<b>A Tale That Wasn't Right</b>"
+    assert_equal "<b>A Tale That Wasn't Right</b>", @response.body
   end
 
   test "cell(..) with #call" do
     get :view_with_cell_with_call
-    @response.body.must_equal "<b>A Tale That Wasn't Right</b>"
+    assert_equal "<b>A Tale That Wasn't Right</b>", @response.body
   end
 
   # Controller#concept
   test "Controller#concept(..).call" do
     get :action_with_concept_with_call
-    @response.body.must_equal "<b>A Tale That Wasn't Right</b>" # TODO: test options/with twin.
+    assert_equal "<b>A Tale That Wasn't Right</b>", @response.body # TODO: test options/with twin.
   end
 
   # Controller#cell
   test "Controller#cell(..).call" do
     get :action_with_cell_with_call
-    @response.body.must_equal "<b>A Tale That Wasn't Right</b>" # TODO: test options/with twin.
+    assert_equal "<b>A Tale That Wasn't Right</b>", @response.body # TODO: test options/with twin.
   end
 end


### PR DESCRIPTION
> NoMethodError: undefined method `assert_equal' for nil:NilClass

You can reproduce the occasional failure reliably by running only `test/rails_extensions_test.rb`, ie. `rake test TEST=test/rails_extensions_test.rb`  This is because the `ctx` requires the rspec-style `describe` block and so is only accidentally set when the tests are all run together.

Switching back to (ahem, _proper_ :) `assert_*` style assertions fixes this.