### PR TITLE
Travis updates, ruby 2.2, head (allowed to fail) and gitter notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-#  - 2.2
+  - ruby-head
+  - 2.2
   - 2.1
   - 2.0.0
   - 1.9.3
@@ -16,8 +17,20 @@ script: bundle exec rake
 
 notifications:
   irc: "irc.freenode.org#cells"
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/   <--- ADD WEBHOOK ID HERE
+
 gemfile:
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.0.gemfile
   - gemfiles/rails3.2.gemfile
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head
+
+before_install:
+  - gem update bundler

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -10,3 +10,4 @@ gemspec :path => "../"
 
 gem "rack-cache", "< 1.3.0", platform: :ruby_19
 gem "rack-cache", "< 1.3.0", platform: :jruby
+gem "test-unit", "~> 3.0",   platform: :ruby_22


### PR DESCRIPTION
Someone with write access will need to go to gitter to get the URL, you go here and click on Travis and grab the URL
<img width="361" alt="skitch" src="https://cloud.githubusercontent.com/assets/50139/10488836/cf7e467e-7257-11e5-83d6-fc953fbc7964.png">