### PR TITLE
extract builder support into a module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ gem "railties", "~> 4.2.0"
 gem "activemodel", "~> 4.2.0"
 gem "minitest", "~> 5.2"
 gem "cells-erb"#, path: "../cells-erb"
+gem "benchmark-ips"
 
 gemspec

--- a/benchmarks/class_builder.rb
+++ b/benchmarks/class_builder.rb
@@ -1,0 +1,37 @@
+require 'bundler/setup'
+require 'benchmark/ips'
+require "cells"
+require 'cell/view_model'
+
+class ACell < Cell::ViewModel
+  def show
+    ""
+  end
+end
+
+class ACellWithBuilder < Cell::ViewModel
+  include Cell::Builder
+
+  def show
+    ""
+  end
+end
+
+Benchmark.ips do |x|
+  x.report("ACell") { ACell.().() }
+  x.report("ACellWithBuilder") { ACellWithBuilder.().() }
+  x.compare!
+end
+
+__END__
+
+Calculating -------------------------------------
+               ACell    25.212k i/100ms
+    ACellWithBuilder    21.394k i/100ms
+-------------------------------------------------
+               ACell    378.206k (± 5.2%) i/s -      1.891M
+    ACellWithBuilder    293.788k (± 4.7%) i/s -      1.476M
+
+Comparison:
+               ACell:   378206.2 i/s
+    ACellWithBuilder:   293788.4 i/s - 1.29x slower

--- a/benchmarks/class_builder.rb
+++ b/benchmarks/class_builder.rb
@@ -26,12 +26,12 @@ end
 __END__
 
 Calculating -------------------------------------
-               ACell    25.212k i/100ms
-    ACellWithBuilder    21.394k i/100ms
+               ACell    25.710k i/100ms
+    ACellWithBuilder    19.948k i/100ms
 -------------------------------------------------
-               ACell    378.206k (± 5.2%) i/s -      1.891M
-    ACellWithBuilder    293.788k (± 4.7%) i/s -      1.476M
+               ACell    419.631k (± 5.0%) i/s -      2.108M
+    ACellWithBuilder    291.924k (± 5.7%) i/s -      1.476M
 
 Comparison:
-               ACell:   378206.2 i/s
-    ACellWithBuilder:   293788.4 i/s - 1.29x slower
+               ACell:   419630.8 i/s
+    ACellWithBuilder:   291923.5 i/s - 1.44x slower

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -20,7 +20,6 @@ end
 
 require "cell/caching"
 require "cell/caching/notification"
-require "uber/builder"
 require "cell/prefixes"
 require "cell/self_contained"
 require "cell/layout"
@@ -30,6 +29,7 @@ require "cell/util"
 require "cell/view_model"
 require "cell/concept"
 require "cell/escaped"
+require "cell/builder"
 
 
 require "cell/railtie" if defined?(Rails)

--- a/lib/cell/builder.rb
+++ b/lib/cell/builder.rb
@@ -1,0 +1,16 @@
+require "uber/builder"
+
+module Cell
+  module Builder
+    def self.included(base)
+      base.send :include, Uber::Builder
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def build(*args)
+        class_builder.call(*args).new(*args) # Uber::Builder::class_builder.
+      end
+    end
+  end
+end

--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -10,7 +10,6 @@ module Cell
 
     extend Uber::InheritableAttr
     extend Uber::Delegates
-    include Uber::Builder
 
     inheritable_attr :view_paths
     self.view_paths = ["app/cells"]
@@ -66,8 +65,8 @@ module Cell
         build(model, options)
       end
 
-      def build(*args) # semi-public.
-        class_builder.call(*args).new(*args) # Uber::Builder::class_builder.
+      def build(*args)
+        new(*args)
       end
 
     private

--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -65,9 +65,7 @@ module Cell
         build(model, options)
       end
 
-      def build(*args)
-        new(*args)
-      end
+      alias build new # semi-public for Cell::Builder
 
     private
       def class_from_cell_name(name)

--- a/test/builder_test.rb
+++ b/test/builder_test.rb
@@ -5,6 +5,8 @@ class BuilderTest < MiniTest::Spec
   Hit  = Struct.new(:title)
 
   class SongCell < Cell::ViewModel
+    include Cell::Builder
+
     builds do |model, options|
       if model.is_a? Hit
         HitCell


### PR DESCRIPTION
After some benchmarks I found out that the builder stuff cost ~45% of time for a cell.

```
# ruby benchmarks/class_builder.rb
Calculating -------------------------------------
               ACell    25.710k i/100ms
    ACellWithBuilder    19.948k i/100ms
-------------------------------------------------
               ACell    419.631k (± 5.0%) i/s -      2.108M
    ACellWithBuilder    291.924k (± 5.7%) i/s -      1.476M

Comparison:
               ACell:   419630.8 i/s
    ACellWithBuilder:   291923.5 i/s - 1.44x slower
```

Now it's extracted to a module to speed up a normal cell. 30% of the speed came from removing the builder from a basic Cell and 15% came from the `alias build new`, which optimize the hook.

NOTE: The Benchmark is included in this PR