### PR TITLE
remove doubled include / extend

### DIFF
--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -52,8 +52,6 @@ module Cell
         delegates :model, *names # Uber::Delegates.
       end
 
-      include Helpers
-
       # Public entry point. Use this to instantiate cells with builders.
       #
       #   SongCell.(@song)


### PR DESCRIPTION
The `Helpers` module is already `extend` some line above.