### PR TITLE
remove comment

### DIFF
--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -136,7 +136,7 @@ module Cell
     end
 
     include Rendering
-    # alias_method :to_s, :call # FIXME: why doesn't this work?
+
     def to_s
       call
     end


### PR DESCRIPTION
```
# alias_method :to_s, :call # FIXME: why doesn't this work?
```
`alias_method` can't work here! `alias_method` creates a alias named alias to the *current* target method, but call would be overwritten by some modules. This results in the fact that `to_s` points to the original `call` method and not to the module overwrite one.