### PR TITLE
⚠️ shadowing outer local variable - app

### DIFF
--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -26,7 +26,7 @@ module Cell
         end
       end
 
-      ActiveSupport.on_load(:action_view) do |app|
+      ActiveSupport.on_load(:action_view) do
         self.class_eval do
           include ::Cell::RailsExtensions::ActionView
         end


### PR DESCRIPTION
Here's a tiny patch that removes a Ruby warning.

There are several more unused block arguments that can be removed but I'm not gonna touch them here, because removing this `app` is enough for eliminating the warning.