### PR TITLE
Escaped.property now accepts multiple property names to remain consis…

### DIFF
--- a/lib/cell/escaped.rb
+++ b/lib/cell/escaped.rb
@@ -4,14 +4,16 @@ module Cell::ViewModel::Escaped
   end
 
   module Property
-    def property(name, *args)
+    def property(*names)
       super.tap do # super defines #title
         mod = Module.new do
-          define_method(name) do |options={}|
-            value = super() # call the original #title.
-            return value unless value.is_a?(String)
-            return value if options[:escape] == false
-            escape!(value)
+          names.each do |name|
+            define_method(name) do |options={}|
+              value = super() # call the original #title.
+              return value unless value.is_a?(String)
+              return value if options[:escape] == false
+              escape!(value)
+            end
           end
         end
         include mod

--- a/test/property_test.rb
+++ b/test/property_test.rb
@@ -20,6 +20,7 @@ class EscapedPropertyTest < MiniTest::Spec
     include Escaped
     property :title
     property :artist
+    property :copyright, :lyrics
 
     def title(*)
       "#{super}</b>" # super + "</b>" still escapes, but this is Rails.
@@ -30,10 +31,16 @@ class EscapedPropertyTest < MiniTest::Spec
     end
   end
 
-  let (:song) { Struct.new(:title, :artist).new("<b>She Sells And Sand Sandwiches", Object) }
+  let (:song) do
+    Struct
+      .new(:title, :artist, :copyright, :lyrics)
+      .new("<b>She Sells And Sand Sandwiches", Object, "<a>Copy</a>", "<i>Words</i>")
+  end
 
   # ::property escapes, everywhere.
   it { SongCell.(song).title.must_equal "&lt;b&gt;She Sells And Sand Sandwiches</b>" }
+  it { SongCell.(song).copyright.must_equal "&lt;a&gt;Copy&lt;/a&gt;" }
+  it { SongCell.(song).lyrics.must_equal "&lt;i&gt;Words&lt;/i&gt;" }
   # no escaping for non-strings.
   it { SongCell.(song).artist.must_equal Object }
   # no escaping when escape: false


### PR DESCRIPTION
…tent with the default property method. Fixes #359.