### PR TITLE
Cell::I18n

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gem "activemodel", "~> 4.2.0"
 gem "minitest", "~> 5.2"
 gem "cells-erb"#, path: "../cells-erb"
 gem "benchmark-ips"
+gem 'rails'
 
 gemspec

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -30,6 +30,6 @@ require "cell/view_model"
 require "cell/concept"
 require "cell/escaped"
 require "cell/builder"
-
+require 'cell/i18n'
 
 require "cell/railtie" if defined?(Rails)

--- a/lib/cell/i18n.rb
+++ b/lib/cell/i18n.rb
@@ -1,0 +1,17 @@
+module Cell::I18n
+  def t(*args)
+    options   = args.last.is_a?(Hash) ? args.pop.dup : {}
+    path = i18n_scoped_path(args.shift)
+    super(path, options)
+  end
+
+  def i18n_scoped_path(key)
+    concept = self.class.name.deconstantize.demodulize.underscore
+    cell_name = self.class.name.demodulize.underscore
+
+    relative_path = ['cells', concept, cell_name].reject(&:blank?).join('.')
+
+    return "#{relative_path}#{key}" if key.starts_with?('.')
+    key
+  end
+end

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class I18nConcept
+  class Testing < Cell::ViewModel
+    include Cell::I18n
+  end
+end
+
+class NoModuleCell < Cell::ViewModel
+  include Cell::I18n
+end
+
+class CellI18nUnitTest < MiniTest::Spec
+  describe '#i18n_scoped_path' do
+    let(:i18n_cell) { I18nConcept::Testing.new }
+    let(:no_module_cell) { NoModuleCell.new }
+
+    it 'handles no module cells and returns a scoped key if the key starts with .' do
+      no_module_cell.i18n_scoped_path('.test').must_equal 'cells.no_module_cell.test'
+    end
+
+    it 'returns a scoped key if the key starts with .' do
+      i18n_cell.i18n_scoped_path('.test').must_equal 'cells.i18n_concept.testing.test'
+    end
+
+    it 'returns a non-scoped key' do
+      i18n_cell.i18n_scoped_path('test.test').must_equal 'test.test'
+    end
+  end
+end


### PR DESCRIPTION
This PR is ongoing and tries to complete the work started in #279
fixes #272 

This scopes the translation key to the following:
Given a Cell called `I18nConcept::Testing` a call to `t('.test')` will produce the following key:
`cells.i18n_concept.testing.test`
