### PR TITLE
Pull current controller's helpers into the class during request in the same way as ActionView::Base

### DIFF
--- a/lib/cell/cell_collection.rb
+++ b/lib/cell/cell_collection.rb
@@ -1,0 +1,28 @@
+module Cell
+  class CellCollection
+
+    attr_reader :collection, :cells
+    alias_method :model, :collection
+
+    def initialize(collection=nil, options={}, klass)
+      @collection = collection
+      @collection_join = options.delete(:collection_join)
+      @cells = collection.collect { |model| klass.build(model, options) }
+    end
+
+    def call(state=:show, *args)
+      content = call_sells(state, *args)
+      content.join @collection_join
+    end
+
+    def to_s
+      call
+    end
+
+  private
+    # Calls collection of cells.
+    def call_sells(state, *args) # private.
+      cells.collect { |cell| cell.call(state, *args) }
+    end
+  end
+end

--- a/lib/cell/cell_collection.rb
+++ b/lib/cell/cell_collection.rb
@@ -11,7 +11,7 @@ module Cell
     end
 
     def call(state=:show, *args)
-      content = call_sells(state, *args)
+      content = call_cells(state, *args)
       content.join @collection_join
     end
 
@@ -21,7 +21,7 @@ module Cell
 
   private
     # Calls collection of cells.
-    def call_sells(state, *args) # private.
+    def call_cells(state, *args) # private.
       cells.collect { |cell| cell.call(state, *args) }
     end
   end

--- a/lib/cell/concept.rb
+++ b/lib/cell/concept.rb
@@ -5,8 +5,23 @@ module Cell
 
     # TODO: this should be in Helper or something. this should be the only entry point from controller/view.
     class << self
-      def class_from_cell_name(name)
-        name.camelize.constantize
+      def class_from_cell_name(name, controller)
+        @cell_class ||= begin
+          supports_path = controller.supports_path?
+          routes  = controller.respond_to?(:_routes)  && controller._routes
+          helpers = controller.respond_to?(:_helpers) && controller._helpers
+
+          Class.new(name.camelize.constantize) do
+            if routes
+              include routes.url_helpers(supports_path)
+              include routes.mounted_helpers
+            end
+
+            if helpers
+              include helpers
+            end
+          end
+        end
       end
 
       def controller_path

--- a/lib/cell/railtie.rb
+++ b/lib/cell/railtie.rb
@@ -5,12 +5,6 @@ module Cell
     require 'cell/rails'
     config.cells = ActiveSupport::OrderedOptions.new
 
-    initializer('cells.attach_router') do |app|
-      ViewModel.class_eval do
-        include app.routes.url_helpers # TODO: i hate this, make it better in Rails.
-      end
-    end
-
     # ruthlessly stolen from the zurb-foundation gem.
     initializer 'cells.update_asset_paths' do |app|
       Array(app.config.cells.with_assets).each do |cell_class|
@@ -31,17 +25,11 @@ module Cell
           include ::Cell::RailsExtensions::ActionView
         end
       end
+
+      CellCollection.send(:include, RailsExtensions::CellCollection)
     end
 
     initializer "cells.include_default_helpers" do
-      # include asset helpers (image_path, font_path, ect)
-      ViewModel.class_eval do
-        include ActionView::Helpers::FormHelper # includes ActionView::Helpers::UrlHelper, ActionView::Helpers::FormTagHelper
-        include ::Cell::RailsExtensions::HelpersAreShit
-
-        include ActionView::Helpers::AssetTagHelper
-      end
-
       # set VM#cache_store, etc.
       ViewModel.send(:include, RailsExtensions::ViewModel)
     end

--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -32,7 +32,10 @@ module Cell
     module Helpers
       # Constantizes name, call builders and returns instance.
       def cell(name, *args) # classic Rails fuzzy API.
-        class_from_cell_name(name, options[:controller]).(*args)
+        options = args.extract_options!
+        controller = options[:controller]
+        args << options
+        class_from_cell_name(name, controller).(*args)
       end
     end
     extend Helpers


### PR DESCRIPTION
I've opened this pull request in the hopes of hashing out the recurring issues with providing cells with a stable access to existing framework helpers. This is still a work in progress. But I was hoping to get your input early. I am well aware of your distaste for [Rails] helpers, but having access to them consistently would mean  a solid widget tool-kit capable of rendering any link/form without constantly hitting odd overrides from the initialization process.

At the moment I've some testing to do.