### PR TITLE
Use render with a block

### DIFF
--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -80,28 +80,28 @@ module Cell
     module Rendering
       # Invokes the passed method (defaults to :show) while respecting caching.
       # In Rails, the return value gets marked html_safe.
-      def call(state=:show, *args)
-        content = render_state(state, *args)
+      def call(state=:show, *args, &block)
+        content = render_state(state, *args, &block)
         content.to_s
       end
 
       # render :show
-      def render(options={})
+      def render(options={}, &block)
         options = normalize_options(options)
-        render_to_string(options)
+        render_to_string(options, &block)
       end
 
     private
-      def render_to_string(options)
+      def render_to_string(options, &block)
         template = find_template(options)
-        content  = render_template(template, options)
+        content  = render_template(template, options, &block)
 
         # TODO: allow other (global) layout dirs.
         with_layout(options, content)
       end
 
-      def render_state(*args)
-        __send__(*args)
+      def render_state(*args, &block)
+        __send__(*args, &block)
       end
 
       def with_layout(options, content)

--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -2,7 +2,15 @@ require 'test_helper'
 
 class CellTest < MiniTest::Spec
   class SongCell < Cell::ViewModel
+    self.view_paths = ['test/fixtures']
+
     def show
+    end
+
+    def show_with_block(&block)
+      render do
+        block
+      end
     end
   end
   # ::rails_version
@@ -10,4 +18,7 @@ class CellTest < MiniTest::Spec
 
   # #options
   it { SongCell.new(nil, genre: "Punkrock").send(:options)[:genre].must_equal "Punkrock" }
+
+  # #block
+  it { SongCell.new(nil, genre: "Punkrock").(:show_with_block) { "hello" }.must_equal "<b>hello</b>" }
 end

--- a/test/fixtures/cell_test/song/show_with_block.erb
+++ b/test/fixtures/cell_test/song/show_with_block.erb
@@ -1,0 +1,1 @@
+<b><%= yield.call %></b>


### PR DESCRIPTION
This is mostly a question instead of a PR to be merged (just because its easier to explain with ruby hahah)

my problem is, call a cell with any content to be included inside it, consider `BoldCell` that put any text inside a `<b></b>` tag

```ruby
BoldCell.new(nil).() do
  "hello"
end
```

and returns

```html
<b>hello</b>
```

I wrote the test under `test/cell_test.rb` and modified to support this, but this is really ugly, specially the need for:

```ruby
def show_with_block(&block)
  render do
    block
  end
end
```

on the cell 😿 

soooooo... whats the best way to do expected using _the cells way_ thank you! 