### PR TITLE
Failing scenario for render with block

### DIFF
--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -10,6 +10,10 @@ class CellTest < MiniTest::Spec
     def show_with_block(&block)
       render(&block)
     end
+
+    def show_inception
+      render
+    end
   end
 
   # #options
@@ -17,4 +21,7 @@ class CellTest < MiniTest::Spec
 
   # #block
   it { SongCell.new(nil, genre: "Punkrock").(:show_with_block) { "hello" }.must_equal "<b>hello</b>\n" }
+
+  # #block inside a block (inception!)
+  it { SongCell.new(nil, genre: "Punkrock").(:show_inception).must_equal "<b>inside the b tag</b>\n" }
 end

--- a/test/fixtures/cell_test/song/show_inception.erb
+++ b/test/fixtures/cell_test/song/show_inception.erb
@@ -1,0 +1,1 @@
+<%= cell('cell_test/song', nil).call(:show_with_block) do %>inside the b tag<% end %>


### PR DESCRIPTION
Just opened this PR while I'm trying to figure out the solution

When calling the cell and pass a block inside an ERB file, it's duplicating the block...

Inside render if calls `yield` 3 times, will add 3 times the block to cell output, example, the failing scenario is:

```ruby
  1) Failure:
CellTest#test_0003_anonymous [test/cell_test.rb:26]:
--- expected
+++ actual
@@ -1,2 +1,2 @@
-"<b>inside the b tag</b>
+"inside the b tag<b>inside the b tag</b>
 "
```

for

```ruby
def show_with_block(&block)
  render(&block)
end
```

if do

```ruby
def show_with_block(&block)
  yield
  yield
  render(&block)
end
```

it appends the block to output

```ruby
  1) Failure:
CellTest#test_0003_anonymous [test/cell_test.rb:28]:
--- expected
+++ actual
@@ -1,2 +1,2 @@
-"<b>inside the b tag</b>
+"inside the b taginside the b taginside the b tag<b>inside the b tag</b>
 "
```