### PR TITLE
more helpful error when cell helper receives non-cell as argument

### DIFF
--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -28,6 +28,9 @@ module Cell
       # Constantizes name if needed, call builders and returns instance.
       def cell(name, *args, &block) # classic Rails fuzzy API.
         constant = name.is_a?(Class) ? name : class_from_cell_name(name)
+        unless constant.ancestors.include? Cell::ViewModel
+          raise ArgumentError, "#{constant} is not a cell, are you sure everything is spelled correctly?"
+        end
         constant.(*args, &block)
       end
     end

--- a/test/concept_test.rb
+++ b/test/concept_test.rb
@@ -64,7 +64,6 @@ class ConceptTest < MiniTest::Spec
 
   it { Record::Cell.new("Wayne").call(:show).must_equal "Party on, Wayne!" }
 
-
   describe "::cell" do
     it { Cell::Concept.cell("record/cell").must_be_instance_of(      Record::Cell) }
     it { Cell::Concept.cell("record/cell/song").must_be_instance_of  Record::Cell::Song }

--- a/test/concept_test.rb
+++ b/test/concept_test.rb
@@ -32,6 +32,7 @@ module Record
   end
 end
 
+
 module Record
   module Cells
     class Cell < ::Cell::Concept
@@ -81,5 +82,11 @@ class ConceptTest < MiniTest::Spec
     # concept(.., collection: ..)
     it { Cell::Concept.cell("record/cell", nil, context: { controller: Object }).
       concept("record/cell", collection: [1,2], tracks: 24, method: :description).().must_equal "A Tribute To Rancid, with 24 songs! [{:controller=>Object}]A Tribute To Rancid, with 24 songs! [{:controller=>Object}]" }
+  end
+
+  describe '#cell ( with non-cell argument )' do
+    it 'raises error if not given a class that inherits from Cell::ViewModel' do
+      assert_raises(ArgumentError){ Cell::Concept.cell('record', nil, {}) }
+    end
   end
 end


### PR DESCRIPTION
I am a trailblazer noob and I spent about two hours debugging when cell helper failed to render. I had passed 
```
cell( 'similarly/named/operation', {}, {} )
#instead of
cell( 'similarly/named/cell', {}, {} )
```
Because the operation class found by #class_from_cell_name also responds to #call, the operation #call method was throwing "wrong number of arguments, 2 for 1".

I eventually found the issue by doing 
```
  constant.method(:call).source_location # location in Operation
```
which was obviously a bit of a trek.

I think the TrailBlazer convention of using #call can lead to some confusing errors without this kind of argument checking.

Thanks for all the work you've put into cells, I'm enjoying using it!