### PR TITLE
Util::constant_for only searches descendants

### DIFF
--- a/lib/cell/util.rb
+++ b/lib/cell/util.rb
@@ -15,13 +15,11 @@ module Cell::Util
 
     # WARNING: this API might change.
     def self.constant_for(name)
-      constant = Object
-      name.split("/").each do |part|
-        capitalized_part = part.split('_').collect(&:capitalize).join
-        # inherit = false so only descendants are searched
-        constant = constant.const_get(capitalized_part, inherit = false)
-      end
-      constant
+      class_name = name.split("/").collect do |part|
+        part.split('_').collect(&:capitalize).join
+      end.join('::')
+      
+      Object.const_get(class_name)
     end
   end
 end

--- a/lib/cell/util.rb
+++ b/lib/cell/util.rb
@@ -17,7 +17,9 @@ module Cell::Util
     def self.constant_for(name)
       constant = Object
       name.split("/").each do |part|
-        constant = constant.const_get(part.split('_').collect(&:capitalize).join)
+        capitalized_part = part.split('_').collect(&:capitalize).join
+        # inherit = false so only descendants are searched
+        constant = constant.const_get(capitalized_part, inherit = false)
       end
       constant
     end


### PR DESCRIPTION
`Util::constant_for` is used in `class_from_cell_name` to construct a class name
from the cell name.

It uses `const_get` to resolve constants, which by default will resolve
ancestors before descendants.

This fix passes `inherit = false` to `const_get` to ensure that it only
searches descendants.

This restores the 4.0.5 behaviour of `class_from_cell_name`.

Example:

The cell name is 'timesheets/client/overview', but Client is also the
name of an ActiveRecord model.

In 4.0.5 the resolved name would be `Timesheets::Client::Overview`
In 4.1.1 the resolved name is `Clients::Overview` (which is incorrect)
In 4.1.1 + this fix the resolved name is: `Timesheets::Client::Overview`