### PR TITLE
Provide workaround for Rails 5 TestRequest

### DIFF
--- a/lib/cell/testing.rb
+++ b/lib/cell/testing.rb
@@ -53,8 +53,21 @@ module Cell
       return unless controller_class
 
       controller_class.new.tap do |ctl|
-        ctl.request = ::ActionController::TestRequest.new
+        ctl.request = action_controller_test_request
         ctl.instance_variable_set :@routes, ::Rails.application.routes.url_helpers
+      end
+    end
+
+    # Rails specific.
+    def action_controller_test_request
+      ## Rails 5 no longer supports creating a TestRequest without
+      ## providing args to the initializer however we can imitate the
+      ## original behaviour using .create whilst allowing fallbacks
+      ## to the original for older versions of Rails.
+      if ::Rails.version.start_with?('5')
+        ::ActionController::TestRequest.create
+      else
+        ::ActionController::TestRequest.new
       end
     end
 


### PR DESCRIPTION
Rails 5 introduces changes to the TestRequest api, it no
longer supports creating a TestRequest without providing
args to the initializer however we can imitate the
original behaviour using .create instead.

This commit maintains backwards compatibility with older
versions of ActionController.

Fixes #376 