### PR TITLE
Clean up cells tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,10 @@ Rake::TestTask.new(:test) do |test|
   test.libs << 'test'
   test.pattern = 'test/*_test.rb'
   test.verbose = true
+  # Ruby built-in warnings contain way too much noise to be useful. Consider turning them on again when the following issues are accepted in ruby:
+  # * https://bugs.ruby-lang.org/issues/10967 (remove warning: private attribute?)
+  # * https://bugs.ruby-lang.org/issues/12299 (customized warning handling)
+  test.warning = false
 end
 
 # Rake::TestTask.new(:rails) do |test|

--- a/lib/cell/collection.rb
+++ b/lib/cell/collection.rb
@@ -2,12 +2,16 @@ module Cell
   class Collection
     def initialize(ary, options, cell_class)
       options.delete(:collection)
-      self.method = options.delete(:method)                   if options.include?(:method)          # TODO: remove in 5.0.
-      self.collection_join = options.delete(:collection_join) if options.include?(:collection_join) # TODO: remove in 5.0.
+      set_deprecated_options(options) # TODO: remove in 5.0.
 
       @ary        = ary
       @options    = options
       @cell_class = cell_class
+    end
+
+    def set_deprecated_options(options) # TODO: remove in 5.0.
+      self.method = options.delete(:method)                   if options.include?(:method)
+      self.collection_join = options.delete(:collection_join) if options.include?(:collection_join)
     end
 
     module Call

--- a/lib/cell/collection.rb
+++ b/lib/cell/collection.rb
@@ -2,25 +2,19 @@ module Cell
   class Collection
     def initialize(ary, options, cell_class)
       options.delete(:collection)
-      @method     = options.delete(:method)           # TODO: remove in 5.0.
-      @join       = options.delete(:collection_join)  # TODO: remove in 5.0.
+      self.method = options.delete(:method)                   if options.include?(:method)          # TODO: remove in 5.0.
+      self.collection_join = options.delete(:collection_join) if options.include?(:collection_join) # TODO: remove in 5.0.
 
       @ary        = ary
       @options    = options
       @cell_class = cell_class
-
-      deprecate_options!
-    end
-
-    def deprecate_options! # TODO: remove in 5.0.
-      warn "[Cells] The :method option is deprecated. Please use `call(method)` as documented here: http://trailblazer.to/gems/cells/api.html#collection" if @method
-      warn "[Cells] The :collection_join option is deprecated. Please use `join(\"<br>\")` as documented here: http://trailblazer.to/gems/cells/api.html#collection" if @collection_join
     end
 
     module Call
       def call(state=:show)
-        join(@join) { |cell, i| cell.(@method || state) }
+        join(collection_join) { |cell, i| cell.(method || state) }
       end
+
     end
     include Call
 
@@ -48,6 +42,13 @@ module Cell
     end
     include Layout
 
+    # TODO: remove in 5.0.
+    private
+    attr_accessor :collection_join, :method
+
+    extend Gem::Deprecate
+    deprecate :method=, "`call(method)` as documented here: http://trailblazer.to/gems/cells/api.html#collection", 2016, 7
+    deprecate :collection_join=, "`join(\"<br>\")` as documented here: http://trailblazer.to/gems/cells/api.html#collection", 2016, 7
   end
 end
 

--- a/lib/cell/templates.rb
+++ b/lib/cell/templates.rb
@@ -21,7 +21,7 @@ module Cell
 
     def create(prefix, view, options)
       # puts "...checking #{prefix}/#{view}"
-      return unless File.exists?("#{prefix}/#{view}") # DISCUSS: can we use Tilt.new here?
+      return unless File.exist?("#{prefix}/#{view}") # DISCUSS: can we use Tilt.new here?
 
       template_class = options.delete(:template_class)
       template_class.new("#{prefix}/#{view}", options) # Tilt.new()

--- a/test/concept_test.rb
+++ b/test/concept_test.rb
@@ -79,7 +79,9 @@ class ConceptTest < MiniTest::Spec
     it { Cell::Concept.cell("record/cell", nil, context: { controller: Object }).cell("record/cell", nil).must_be_instance_of Record::Cell }
     it { Cell::Concept.cell("record/cell", nil, context: { controller: Object }).concept("record/cell", nil, tracks: 24).(:description).must_equal "A Tribute To Rancid, with 24 songs! [{:controller=>Object}]" }
     # concept(.., collection: ..)
-    it { Cell::Concept.cell("record/cell", nil, context: { controller: Object }).
-      concept("record/cell", collection: [1,2], tracks: 24, method: :description).().must_equal "A Tribute To Rancid, with 24 songs! [{:controller=>Object}]A Tribute To Rancid, with 24 songs! [{:controller=>Object}]" }
+    it do
+      Cell::Concept.cell("record/cell", nil, context: { controller: Object }).
+        concept("record/cell", collection: [1,2], tracks: 24).(:description).must_equal "A Tribute To Rancid, with 24 songs! [{:controller=>Object}]A Tribute To Rancid, with 24 songs! [{:controller=>Object}]" 
+    end
   end
 end

--- a/test/public_test.rb
+++ b/test/public_test.rb
@@ -34,15 +34,26 @@ class PublicTest < MiniTest::Spec
   # ViewModel.cell(collection: []) renders cells.
   it { Cell::ViewModel.cell("public_test/song", collection: [Object, Module]).to_s.must_equal '[Object, {}][Module, {}]' }
 
+  # DISCUSS: should cell.() be the default?
   # ViewModel.cell(collection: []) renders cells with custom join.
-  it { Cell::ViewModel.cell("public_test/song", collection: [Object, Module], collection_join: '<br/>').to_s.must_equal '[Object, {}]<br/>[Module, {}]' }
+  it do
+	Gem::Deprecate::skip_during do
+		Cell::ViewModel.cell("public_test/song", collection: [Object, Module]).join('<br/>') do |cell|
+          cell.()
+        end.must_equal '[Object, {}]<br/>[Module, {}]'
+	end
+  end
 
   # ViewModel.cell(collection: []) passes generic options to cell.
   it { Cell::ViewModel.cell("public_test/song", collection: [Object, Module], genre: 'Metal', context: { ready: true }).to_s.must_equal "[Object, {:genre=>\"Metal\", :context=>{:ready=>true}}][Module, {:genre=>\"Metal\", :context=>{:ready=>true}}]" }
 
   # ViewModel.cell(collection: [], method: :detail) invokes #detail instead of #show.
   # TODO: remove in 5.0.
-  it { Cell::ViewModel.cell("public_test/song", collection: [Object, Module], method: :detail).to_s.must_equal '* [Object, {}]* [Module, {}]' }
+  it do
+	Gem::Deprecate::skip_during do
+      Cell::ViewModel.cell("public_test/song", collection: [Object, Module], method: :detail).to_s.must_equal '* [Object, {}]* [Module, {}]'
+    end
+  end
 
   # ViewModel.cell(collection: []).() invokes #show.
   it { Cell::ViewModel.cell("public_test/song", collection: [Object, Module]).().must_equal '[Object, {}][Module, {}]' }

--- a/test/public_test.rb
+++ b/test/public_test.rb
@@ -37,11 +37,11 @@ class PublicTest < MiniTest::Spec
   # DISCUSS: should cell.() be the default?
   # ViewModel.cell(collection: []) renders cells with custom join.
   it do
-	Gem::Deprecate::skip_during do
-		Cell::ViewModel.cell("public_test/song", collection: [Object, Module]).join('<br/>') do |cell|
+    Gem::Deprecate::skip_during do
+      Cell::ViewModel.cell("public_test/song", collection: [Object, Module]).join('<br/>') do |cell|
           cell.()
-        end.must_equal '[Object, {}]<br/>[Module, {}]'
-	end
+      end.must_equal '[Object, {}]<br/>[Module, {}]'
+    end
   end
 
   # ViewModel.cell(collection: []) passes generic options to cell.
@@ -50,7 +50,7 @@ class PublicTest < MiniTest::Spec
   # ViewModel.cell(collection: [], method: :detail) invokes #detail instead of #show.
   # TODO: remove in 5.0.
   it do
-	Gem::Deprecate::skip_during do
+    Gem::Deprecate::skip_during do
       Cell::ViewModel.cell("public_test/song", collection: [Object, Module], method: :detail).to_s.must_equal '* [Object, {}]* [Module, {}]'
     end
   end


### PR DESCRIPTION
Running `rake test` on the master branch generates a lot of noise. These changes suppress this noise, so you can focus on the status of the tests. I have made the following changes:

Suppress the built-in ruby warnings during testing. These warnings mostly contain messages like "warning: private attribute?" and "value xxx not initialized". There are several issues in the ruby bugtracker to fix this. To name a few:

- https://bugs.ruby-lang.org/issues/10967
- https://bugs.ruby-lang.org/issues/12299

Consider turning these warnings on again when these issues are resolved (and the associated ruby versions are widely distributed).

Replace the `File.exists` check with the equivalent, but non-deprecated `File.exist`. This was the only built-in warning that actually made sense.

Use the standard Gem::Deprecate module to generate deprecation warnings. These warnings automatically include filenames and line numbers in the deprecation messages and can be suppressed during testing.