### PR TITLE
Access content cell from external layout

### DIFF
--- a/lib/cell/collection.rb
+++ b/lib/cell/collection.rb
@@ -43,7 +43,7 @@ module Cell
         layout = @options.delete(:layout) # we could also override #initialize and that there?
 
         content = super # DISCUSS: that could come in via the pipeline argument.
-        ViewModel::Layout::External::Render.(content, @ary, layout, @options)
+        ViewModel::Layout::External::Render.(content, @ary, layout, self, @options)
       end
     end
     include Layout

--- a/lib/cell/layout.rb
+++ b/lib/cell/layout.rb
@@ -41,14 +41,14 @@ module Cell
       module External
         def call(*)
           content = super
-          Render.(content, model, @options[:layout], @options)
+          Render.(content, model, @options[:layout], self, @options)
         end
 
-        Render = ->(content, model, layout, options) do # WARNING: THIS IS NOT FINAL API.
-          return content unless layout = layout # TODO: test when invoking cell without :layout.
+        Render = ->(content, model, layout, content_cell, options) do # WARNING: THIS IS NOT FINAL API.
+          return content unless layout # TODO: test when invoking cell without :layout.
 
           # DISCUSS: should we allow instances, too? we could cache the layout cell.
-          layout.new(model, context: options[:context]).(&lambda { content })
+          layout.new(model, context: options[:context], content_cell: content_cell).(&lambda { content })
         end
       end # External
     end

--- a/lib/cell/layout.rb
+++ b/lib/cell/layout.rb
@@ -50,6 +50,13 @@ module Cell
           # DISCUSS: should we allow instances, too? we could cache the layout cell.
           layout.new(model, context: options[:context], content_cell: content_cell).(&lambda { content })
         end
+
+        module Content
+          def content_block(part)
+            return @options[:content_cell].send(part) if @options[:content_cell].respond_to?(part)
+            yield if block_given?
+          end
+        end # Content
       end # External
     end
   end

--- a/test/fixtures/comment/layout/show.erb
+++ b/test/fixtures/comment/layout/show.erb
@@ -1,1 +1,3 @@
-$layout.erb{<%= yield %>, <%= context.inspect %>}
+$layout.erb{
+title=<%= content_block(:beer) { beer }%>
+<%= yield %>, <%= beer %>}

--- a/test/fixtures/comment/show/show.erb
+++ b/test/fixtures/comment/show/show.erb
@@ -1,1 +1,1 @@
-$show.erb, <%= context.inspect %>
+$show.erb, <%= beer %>

--- a/test/layout_test.rb
+++ b/test/layout_test.rb
@@ -65,27 +65,42 @@ module Comment
     def show
       render + render
     end
+
+    def title
+      "Show comments"
+    end
+
+    def beer
+      !context.nil? && context[:beer] ? "beer" : "no beer"
+    end
   end
 
   class LayoutCell < Cell::ViewModel
+    include Layout::External::Content
     self.view_paths = ['test/fixtures']
+
+    def beer
+      !context.nil? && context[:beer] ? "layout_beer" : "no layout_beer"
+    end
   end
 end
 
 class ExternalLayoutTest < Minitest::Spec
   it do
     Comment::ShowCell.new(nil, layout: Comment::LayoutCell, context: { beer: true }).
-      ().must_equal "$layout.erb{$show.erb, {:beer=>true}\n$show.erb, {:beer=>true}\n, {:beer=>true}}\n"
+      ().must_equal "$layout.erb{\ntitle=beer\n$show.erb, beer\n$show.erb, beer\n, layout_beer}\n"
   end
 
   # collection :layout
   it do
     Cell::ViewModel.cell("comment/show", collection: [Object, Module], layout: Comment::LayoutCell).().
-      must_equal "$layout.erb{$show.erb, nil
-$show.erb, nil
-$show.erb, nil
-$show.erb, nil
-, nil}
+      must_equal "$layout.erb{
+title=no layout_beer
+$show.erb, no beer
+$show.erb, no beer
+$show.erb, no beer
+$show.erb, no beer
+, no layout_beer}
 "
   end
 end


### PR DESCRIPTION
The only way to communicate between an external layout and its content is through the `yield` call, while an internal layout can call all content cell methods. 

This patch adds the `@option[:content_cell]` option to layout cells provides the `Cell::Viewmodel::Layout::External::Content` interface for communication between an external layout cell and the content cell it wraps. This interface is convenient if you want to create standard components (e.g. for bootstrap) that have multiple content areas, such as a panel. With this interface, such a layout cell can be defined as follows:
```
module Layout
  module Cell
    class Panel < Trailblazer::Cell
      include ::Cell::ViewModel::Layout::External::Content

      def footer?
        !content_block(:footer).nil?
      end
    end
  end
end
```
The layout itself pretty straightforward (in this case, i'm using erb):
```
<div class="panel panel-default">
  <div class="panel-heading">
    <%= content_block(:title) { "Default title" } %>
  </div>
  <div class="panel-body"><%= yield %></div>
  <% if footer? %>
      <div class="panel-footer"><%= content_block(:footer) %></div>
  <% end %>
</div>
```
The `Cell::ViewModel::Layout::External interface provides the `content_block(:method)` method. This method checks if the content cell defines `:method`. You can provide a block that will be rendered if it doesn't. If you don't `nil` will be returned. You can render a `SongCell` with this layout as follows:

```
class Song
  module Cell
    class SongCell < ::Trailblazer::Cell
      include ::Cell::ViewModel::Layout::External
      property :song_title
      property :author
      property :year

      def title
        song_title
      end

      def footer
        render "song/footer"
      end
    end
  end
end
```
song.erb:
```
<p><strong>Author:</strong> <%= author %></p>
<p><strong>Year:</strong> <%= year %>
```
song/footer.erb:
```
<a href="edit">Edit this song</a>
```
This patch is completely backwards compatible: all it does is providing the `@option[:content_cell`] option by default to layout cells. The `content_block` functionality is not provided by default; it is completely separated in the `::Cell::ViewModel::Layout::External` module.

This interface is also useful for a full-page layout. Webpages often need a customized page title and footer. Without this patch, you could only customize this context by adding it to the `@options[:context]` option. With this patch, you can directly define this content in your cells.