### PR TITLE
FIX for collections and context

### DIFF
--- a/lib/cell/view_model.rb
+++ b/lib/cell/view_model.rb
@@ -44,7 +44,12 @@ module Cell
       #   SongCell.(collection: Song.all)
       def call(model=nil, options={}, &block)
         if model.is_a?(Hash) and array = model[:collection]
-          return Collection.new(array, model.merge(options), self)
+          merged_context = (model[:context] || {}).merge(options[:context])
+
+          merged_options = model.merge(options)
+          merged_options[:context] = merged_context
+
+          return Collection.new(array, merged_options, self)
         end
 
         build(model, options)


### PR DESCRIPTION
This PR fixes passing context into collections. This probably only affects Cells in rails (since cells-rails is providing the default context that is breaking the collection handling), so there's a potential discussion as to whether this fix should go in Cells or Cells-rails.

If you think the fix is appropriate here let me know and I'll add a test case to this PR.