### PR TITLE
Change const getting by name

### DIFF
--- a/lib/cell/util.rb
+++ b/lib/cell/util.rb
@@ -19,7 +19,7 @@ module Cell::Util
         part.split('_').collect(&:capitalize).join
       end.join('::')
       
-      Object.const_get(class_name)
+      Object.const_get(class_name, false)
     end
   end
 end


### PR DESCRIPTION
Assume that we have cell in Rails with name like this `Foo::Bar::BazCell` (`app/cells/foo/bar/baz_cell.rb`). If this class wasn't preloaded (in development) but class `Bar` was, then we get error `NameError: uninitialized constant Bar::BazCell`.