### PR TITLE
Make controller method public for request specs

### DIFF
--- a/lib/cell/testing.rb
+++ b/lib/cell/testing.rb
@@ -12,6 +12,10 @@ module Cell
       cell_for(Concept, name, *args)
     end
 
+    def controller # FIXME: this won't allow us using let(:controller) in MiniTest.
+      controller_for(self.class.controller_class)
+    end
+
   private
     def cell_for(baseclass, name, model=nil, options={})
       options[:context] ||= {}
@@ -55,10 +59,6 @@ module Cell
       end
     end
     include ControllerFor
-
-    def controller # FIXME: this won't allow us using let(:controller) in MiniTest.
-      controller_for(self.class.controller_class)
-    end
 
     def self.included(base)
       base.class_eval do

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -13,21 +13,21 @@ class ContextTest < MiniTest::Spec
 
   let (:model) { Object.new }
   let (:user) { Object.new }
-  let (:controller) { Object.new }
+  let (:example_controller) { Object.new }
 
   it do
-    cell = ParentCell.(model, admin: true, context: { user: user, controller: controller })
+    cell = ParentCell.(model, admin: true, context: { user: user, controller: example_controller })
     # cell.extend(ParentController)
 
     cell.model.must_equal model
-    cell.controller.must_equal controller
+    cell.controller.must_equal example_controller
     cell.user.must_equal user
 
     # nested cell
     child = cell.cell("context_test/parent", "")
 
     child.model.must_equal ""
-    child.controller.must_equal controller
+    child.controller.must_equal example_controller
     child.user.must_equal user
   end
 end


### PR DESCRIPTION
When using this gem in with request specs in Rails with RSpec - `controller` getter is replaced with private one and this breaks the tests. Although fix is simple, making `controller` method private was done in order to make MiniTest pass.

I have renamed `controller` in MiniTest to `example_controllers` and changed all occurrences of this.

Now it plays nicely with RSpec request specs as currently tested controller is available through default getter.